### PR TITLE
Include path when recursing to deeper directories

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,7 @@ function getRequiredFiles(context, path) {
     const filePath = modulePath.join(context, path, file)
 
     if (is_dir(filePath)) {
-      requiredFiles = getRequiredFiles(context, file).concat(requiredFiles)
+      requiredFiles = getRequiredFiles(context, modulePath.join(path, file)).concat(requiredFiles)
     } else {
       /\.html$/.test(file) && (
         requiredFiles = requiredFiles.concat(modulePath.join(path, file))


### PR DESCRIPTION
Hello! I found a bug today when I tried to include more than 2 levels of directories in my templates. As you can see in the fix, the current `path` wasn't being included when recursing down into deeper directories.

My template structure looks like:

```
templates/
├── partials
│   ├── footer.html
│   ├── head.html
│   ├── nav.html
│   ├── spec.html
│   ├── spec_nav.html
│   └── try.html
└── v1
    ├── index.html
    └── spec
        └── index.html
```

I would get an error when trying to read `templates/v1/spec/index.html`: 

```fs.js:126
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir '/Users/rob/Sites/pwv/toml.io/templates/spec'
    at Object.readdirSync (fs.js:795:3)
    at getRequiredFiles (/Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/utils.js:41:18)
    at /Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/utils.js:47:23
    at Array.forEach (<anonymous>)
    at getRequiredFiles (/Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/utils.js:43:9)
    at /Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/utils.js:47:23
    at Array.forEach (<anonymous>)
    at Object.getRequiredFiles (/Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/utils.js:43:9)
    at FileIncludeWebpackPlugin.process (/Users/rob/Sites/pwv/toml.io/node_modules/file-include-webpack-plugin/src/index.js:44:25)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:7:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at Compiler.emitAssets (/Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compiler.js:481:19)
    at onCompiled (/Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Watching.js:51:19)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compiler.js:671:15
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compiler.js:668:31
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compilation.js:1385:35
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compilation.js:1376:32
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compilation.js:1371:36
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/Hook.js:154:20)
    at /Users/rob/Sites/pwv/toml.io/node_modules/webpack/lib/Compilation.js:1367:32
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/rob/Sites/pwv/toml.io/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1) {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: '/Users/rob/Sites/pwv/toml.io/templates/spec'
}
```

It was looking for a file in `templates/spec` instead of `templates/v1/spec`. This PR fixes it! Thanks for this awesome package by the way!