### PR TITLE
Throw custom error with message when partial not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,15 @@ class FileIncludeWebpackPlugin {
       // add partials to watch
       compilation.fileDependencies.add(partialPath)
 
-      return utils.getFileContent(partialPath, args)
+      try {
+        return utils.getFileContent(partialPath, args)
+      } catch (err) {
+        if (err.message.match(/no such file or directory/)) {
+          throw new Error(`Partial ${partial} not found, referenced in file ${file}`)
+        } else {
+          throw err
+        }
+      }
     })
 
     if (this.replace) {


### PR DESCRIPTION
Instead of a generic ENOENT error when a partial is referenced in an `@@include` but not found, this raises a custom error with a message that explains exactly what happened:

`Partial partials/head.html not found, referenced in file /Users/rob/Sites/my_site/templates/index.html`